### PR TITLE
Server-block identifier can be an IP range. Fixes #6

### DIFF
--- a/core/dhcpserver/config.go
+++ b/core/dhcpserver/config.go
@@ -52,15 +52,15 @@ func (cfg *Config) AddPlugin(p plugin.Plugin) {
 	cfg.plugins = append(cfg.plugins, p)
 }
 
-func keyForConfig(serverBlockIndex, serverBlockKeyIndex int) string {
-	return fmt.Sprintf("%d:%d", serverBlockIndex, serverBlockKeyIndex)
+func keyForConfig(serverBlockIndex int) string {
+	return fmt.Sprintf("%d", serverBlockIndex)
 }
 
 // GetConfig gets the Config that corresponds to c
 // if none exist nil is returned
 func GetConfig(c *caddy.Controller) *Config {
 	ctx := c.Context().(*dhcpContext)
-	key := keyForConfig(c.ServerBlockIndex, c.ServerBlockKeyIndex)
+	key := keyForConfig(c.ServerBlockIndex)
 
 	cfg := ctx.keyToConfig[key]
 	return cfg

--- a/core/dhcpserver/interface.go
+++ b/core/dhcpserver/interface.go
@@ -20,6 +20,9 @@ func findInterface(cfg *Config) bool {
 	return true
 }
 
+// findInterfaceByIP searches for the network interface that has
+// ip assigned to it. The IP address must be the same, IPs in
+// the same subnet do not count as a match
 func findInterfaceByIP(ip net.IP) (*net.Interface, error) {
 	ifaces, err := net.Interfaces()
 	if err != nil {
@@ -47,4 +50,92 @@ func findInterfaceByIP(ip net.IP) (*net.Interface, error) {
 	}
 
 	return nil, fmt.Errorf("failed to find interface for %s", ip.String())
+}
+
+// findInterfaceContainingIPs searches for the network interface that
+// contains the given IP address in one of it's attached local networks
+func findInterfaceContainingIP(ip net.IP) (*net.Interface, *net.IPNet, error) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	for _, iface := range ifaces {
+		addrs, err := iface.Addrs()
+		if err != nil {
+			return nil, nil, err
+		}
+
+		for _, a := range addrs {
+			ipNet, ok := a.(*net.IPNet)
+			if !ok {
+				continue
+			}
+
+			if ipNet.Contains(ip) {
+				return &iface, ipNet, nil
+			}
+
+		}
+	}
+
+	return nil, nil, fmt.Errorf("failed to find interface with %s", ip.String())
+}
+
+// tryInterfaceNameOrIP first tries to parse a CIDR IP subnet
+// notation in value and will fill the IP and IPNet values of
+// cfg accordingly. If value is not a valid CIDR notation
+// it will assume value is the name of the interface and will
+// lookup the IP configuration there. If that fails too, an
+// error is returned
+func tryInterfaceNameOrIP(value string, cfg *Config) error {
+	ip, ipNet, err := net.ParseCIDR(value)
+	if err == nil {
+		cfg.IP = ip
+		cfg.Network = *ipNet
+		return nil
+	}
+
+	iface, err := net.InterfaceByName(value)
+	if err != nil {
+		return err
+	}
+
+	addr, err := iface.Addrs()
+	if err != nil {
+		return err
+	}
+
+	foundIPv4 := false
+
+	for _, a := range addr {
+		ipn, ok := a.(*net.IPNet)
+		if !ok {
+			// not an IPNet, skip this one
+			continue
+		}
+
+		if ipn.IP.To4() == nil {
+			// not an IPv4 network
+			continue
+		}
+
+		if foundIPv4 {
+			return fmt.Errorf("interface names can only be used with one subnet assigned")
+		}
+
+		foundIPv4 = true
+
+		ip = ipn.IP
+		ipNet = ipn
+	}
+
+	if !foundIPv4 {
+		return fmt.Errorf("no usable subnet found")
+	}
+
+	cfg.IP = ip
+	cfg.Network = *ipNet
+
+	return nil
 }

--- a/plugin/ranges/range.go
+++ b/plugin/ranges/range.go
@@ -199,6 +199,8 @@ func setupRange(c *caddy.Controller) error {
 		plg.Ranges = iprange.Merge(append(plg.Ranges, r))
 	}
 
+	plg.L.Debugf("serving %d IP ranges: %v", len(plg.Ranges), plg.Ranges)
+
 	cfg.AddPlugin(func(next plugin.Handler) plugin.Handler {
 		plg.Next = next
 		return plg


### PR DESCRIPTION
The server-block identifier can now be a range definition like
    192.168.0.100 - 192.168.0.200
In this case the interface is looked up automatically an a range
plugin is configured. This allows for even simpler configuration files