### PR TITLE
Set Server ID for all packets 

### DIFF
--- a/plugin/serverid/plugin.go
+++ b/plugin/serverid/plugin.go
@@ -6,12 +6,14 @@ import (
 
 	"github.com/insomniacslk/dhcp/dhcpv4"
 	"github.com/nextdhcp/nextdhcp/core/dhcpserver"
+	"github.com/nextdhcp/nextdhcp/core/log"
 	"github.com/nextdhcp/nextdhcp/plugin"
 )
 
 type serverID struct {
 	next plugin.Handler
 	id   net.IP
+	L    log.Logger
 }
 
 // Name returns "serverid" and implements plugin.Handler
@@ -24,6 +26,7 @@ func (s *serverID) ServeDHCP(ctx context.Context, req, res *dhcpv4.DHCPv4) error
 	reqID := req.ServerIdentifier()
 	// Drop it if it's not for us
 	if reqID != nil && !reqID.IsUnspecified() && reqID.String() != s.id.String() {
+		s.L.Debugf("ignoring packet with incorrect server ID %q from %s", req.ClientHWAddr, reqID)
 		return dhcpserver.ErrNoResponse
 	}
 

--- a/plugin/serverid/plugin.go
+++ b/plugin/serverid/plugin.go
@@ -30,9 +30,7 @@ func (s *serverID) ServeDHCP(ctx context.Context, req, res *dhcpv4.DHCPv4) error
 		return dhcpserver.ErrNoResponse
 	}
 
-	if dhcpserver.Discover(req) {
-		res.UpdateOption(dhcpv4.OptServerIdentifier(s.id))
-	}
+	res.UpdateOption(dhcpv4.OptServerIdentifier(s.id))
 
 	return s.next.ServeDHCP(ctx, req, res)
 }

--- a/plugin/serverid/setup.go
+++ b/plugin/serverid/setup.go
@@ -3,6 +3,7 @@ package serverid
 import (
 	"github.com/caddyserver/caddy"
 	"github.com/nextdhcp/nextdhcp/core/dhcpserver"
+	"github.com/nextdhcp/nextdhcp/core/log"
 	"github.com/nextdhcp/nextdhcp/plugin"
 )
 
@@ -26,11 +27,14 @@ func setupServerID(c *caddy.Controller) error {
 
 	cfg := dhcpserver.GetConfig(c)
 
+	plg := &serverID{
+		id: cfg.IP,
+	}
+	plg.L = log.GetLogger(c, plg)
+
 	cfg.AddPlugin(func(next plugin.Handler) plugin.Handler {
-		return &serverID{
-			next: next,
-			id:   cfg.IP,
-		}
+		plg.next = next
+		return plg
 	})
 
 	return nil


### PR DESCRIPTION
Some clients, including ChromeOS, require this option for all packets.