### PR TITLE
fix: IP range length and reservation deletion logic

### DIFF
--- a/core/lease/iprange/range.go
+++ b/core/lease/iprange/range.go
@@ -32,7 +32,7 @@ func (r *IPRange) Len() int {
 		return 0
 	}
 
-	return int(end4) - int(start4)
+	return int(end4) - int(start4) + 1
 }
 
 func (r *IPRange) String() string {

--- a/core/lease/iprange/range_test.go
+++ b/core/lease/iprange/range_test.go
@@ -18,21 +18,21 @@ func Test_IPRange_Len(t *testing.T) {
 				Start: net.ParseIP("10.0.0.0"),
 				End:   net.ParseIP("10.0.0.0"),
 			},
-			0,
+			1,
 		},
 		{
 			IPRange{
 				Start: net.ParseIP("10.0.0.0"),
 				End:   net.ParseIP("10.0.0.100"),
 			},
-			100,
+			101,
 		},
 		{
 			IPRange{
 				Start: net.ParseIP("10.0.0.0"),
 				End:   net.ParseIP("10.0.1.100"),
 			},
-			356,
+			357,
 		},
 		// invalid ranges
 		{
@@ -284,6 +284,26 @@ func Test_deleteRange(t *testing.T) {
 				{
 					Start: net.IP{10, 8, 0, 10},
 					End:   net.IP{10, 8, 0, 19},
+				},
+			},
+		},
+
+		// #4 ensure trailing single IPs are retained
+		{
+			I: []*IPRange{
+				{
+					Start: net.ParseIP("10.8.0.10").To4(),
+					End:   net.ParseIP("10.8.0.11").To4(),
+				},
+			},
+			D: &IPRange{
+				Start: net.ParseIP("10.8.0.10").To4(),
+				End:   net.ParseIP("10.8.0.10").To4(),
+			},
+			E: []*IPRange{
+				{
+					Start: net.ParseIP("10.8.0.11").To4(),
+					End:   net.ParseIP("10.8.0.11").To4(),
 				},
 			},
 		},

--- a/core/lease/storage/database.go
+++ b/core/lease/storage/database.go
@@ -219,7 +219,7 @@ func (db *Database) DeleteReservation(ctx context.Context, ip net.IP, cli *lease
 		return ErrClientMismatch
 	}
 
-	if !leased {
+	if leased {
 		return errors.New("reservation not found")
 	}
 

--- a/core/lease/storage/database_test.go
+++ b/core/lease/storage/database_test.go
@@ -1,0 +1,82 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeLeaseStorage struct {
+	findByIPClientID string
+	findByIPLeased   bool
+	findByIPErr      error
+
+	deleteCalls    int
+	deleteIP       net.IP
+	deleteClientID string
+	deleteErr      error
+}
+
+func (f *fakeLeaseStorage) Create(ctx context.Context, ip net.IP, clientID string, leased bool, expiration time.Time) error {
+	return errors.New("not implemented")
+}
+
+func (f *fakeLeaseStorage) Delete(ctx context.Context, ip net.IP, clientID string) error {
+	f.deleteCalls++
+	f.deleteIP = append(net.IP{}, ip...)
+	f.deleteClientID = clientID
+	return f.deleteErr
+}
+
+func (f *fakeLeaseStorage) Update(ctx context.Context, ip net.IP, clientID string, leased bool, expiration time.Time) error {
+	return errors.New("not implemented")
+}
+
+func (f *fakeLeaseStorage) FindByIP(ctx context.Context, ip net.IP) (string, bool, time.Time, error) {
+	return f.findByIPClientID, f.findByIPLeased, time.Time{}, f.findByIPErr
+}
+
+func (f *fakeLeaseStorage) FindByID(ctx context.Context, clientID string) (net.IP, bool, time.Time, error) {
+	return nil, false, time.Time{}, errors.New("not implemented")
+}
+
+func (f *fakeLeaseStorage) ListIPs(ctx context.Context) ([]net.IP, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeLeaseStorage) ListIDs(ctx context.Context) ([]string, error) {
+	return nil, errors.New("not implemented")
+}
+
+func TestDeleteReservationRemovesUnleasedEntries(t *testing.T) {
+	store := &fakeLeaseStorage{
+		findByIPClientID: "client-1",
+		findByIPLeased:   false,
+	}
+	db := NewDatabase(store)
+
+	ip := net.IP{10, 0, 0, 1}
+	err := db.DeleteReservation(context.Background(), ip, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, store.deleteCalls)
+	assert.True(t, ip.Equal(store.deleteIP))
+	assert.Empty(t, store.deleteClientID)
+}
+
+func TestDeleteReservationProtectsLeasedEntries(t *testing.T) {
+	store := &fakeLeaseStorage{
+		findByIPClientID: "client-1",
+		findByIPLeased:   true,
+	}
+	db := NewDatabase(store)
+
+	ip := net.IP{10, 0, 0, 1}
+	err := db.DeleteReservation(context.Background(), ip, nil)
+	require.EqualError(t, err, "reservation not found")
+	assert.Equal(t, 0, store.deleteCalls)
+}


### PR DESCRIPTION
## Summary
- treat IP ranges as inclusive so Len() reports a single address and DeleteFrom retains trailing addresses
- add regression tests for IP ranges and database reservations while fixing DeleteReservation to only reject leased records